### PR TITLE
mise à jour de PHPCS en version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "phpunit/phpunit": "~4.5",
         "besimple/i18n-routing-bundle": "~2.3",
-        "m6web/coke": "~1.2",
-        "m6web/Symfony2-coding-standard": "~1.1",
+        "m6web/coke": "~2.1",
+        "m6web/symfony2-coding-standard": "~3.0",
         "hwi/oauth-bundle": "0.4.*@dev",
         "woecifaun/translation-bridge-bundle": "~0.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "97344381efad40134b5bf56f3503dae0",
+    "hash": "11cb663fe5fb7a6fd011fa7b4ffeab65",
     "packages": [
         {
             "name": "besimple/i18n-routing-bundle",
@@ -1166,20 +1166,20 @@
         },
         {
             "name": "m6web/coke",
-            "version": "v1.2.2",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/M6Web/Coke.git",
-                "reference": "dcc943b4da9a677911504cb0fb5cf4d8f0d962d0"
+                "reference": "fa5cedcdbff2aa62b5db6de068c7ebc142174184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/M6Web/Coke/zipball/dcc943b4da9a677911504cb0fb5cf4d8f0d962d0",
-                "reference": "dcc943b4da9a677911504cb0fb5cf4d8f0d962d0",
+                "url": "https://api.github.com/repos/M6Web/Coke/zipball/fa5cedcdbff2aa62b5db6de068c7ebc142174184",
+                "reference": "fa5cedcdbff2aa62b5db6de068c7ebc142174184",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "~1.5"
+                "squizlabs/php_codesniffer": "~2.3"
             },
             "suggest": {
                 "m6web/symfony2-coding-standard": "Symfony2 PHP CodeSniffer Coding Standard"
@@ -1193,25 +1193,27 @@
                 "MIT"
             ],
             "description": "PHP Code Sniffer configurator",
-            "time": "2014-11-02 18:26:32"
+            "time": "2015-07-27 20:30:44"
         },
         {
             "name": "m6web/symfony2-coding-standard",
-            "version": "v1.2.1",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/M6Web/Symfony2-coding-standard.git",
-                "reference": "51190f81cd40b86b204874b79761ddd5aa2b3023"
+                "reference": "029adf9a539d7f55c60b64a5e2c40cdace47206e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/M6Web/Symfony2-coding-standard/zipball/51190f81cd40b86b204874b79761ddd5aa2b3023",
-                "reference": "51190f81cd40b86b204874b79761ddd5aa2b3023",
+                "url": "https://api.github.com/repos/M6Web/Symfony2-coding-standard/zipball/029adf9a539d7f55c60b64a5e2c40cdace47206e",
+                "reference": "029adf9a539d7f55c60b64a5e2c40cdace47206e",
                 "shasum": ""
             },
+            "require": {
+                "squizlabs/php_codesniffer": "~2.0"
+            },
             "suggest": {
-                "m6web/coke": "PHP CodeSniffer configurator",
-                "squizlabs/php_codesniffer": "PHP CodeSniffer"
+                "m6web/coke": "PHP CodeSniffer configurator"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -1232,7 +1234,7 @@
                 "phpcs",
                 "standard"
             ],
-            "time": "2014-10-07 08:21:43"
+            "time": "2015-07-27 20:42:01"
         },
         {
             "name": "monolog/monolog",
@@ -2360,32 +2362,31 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "1.5.6",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "6f3e42d311b882b25b4d409d23a289f4d3b803d5"
+                "reference": "c1a26c729508f73560c1a4f767f60b8ab6b4a666"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6f3e42d311b882b25b4d409d23a289f4d3b803d5",
-                "reference": "6f3e42d311b882b25b4d409d23a289f4d3b803d5",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/c1a26c729508f73560c1a4f767f60b8ab6b4a666",
+                "reference": "c1a26c729508f73560c1a4f767f60b8ab6b4a666",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
                 "php": ">=5.1.2"
             },
-            "suggest": {
-                "phpunit/php-timer": "dev-master"
-            },
             "bin": [
-                "scripts/phpcs"
+                "scripts/phpcs",
+                "scripts/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-phpcs-fixer": "2.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2394,12 +2395,12 @@
                     "CodeSniffer/CLI.php",
                     "CodeSniffer/Exception.php",
                     "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
                     "CodeSniffer/Report.php",
                     "CodeSniffer/Reporting.php",
                     "CodeSniffer/Sniff.php",
                     "CodeSniffer/Tokens.php",
                     "CodeSniffer/Reports/",
-                    "CodeSniffer/CommentParser/",
                     "CodeSniffer/Tokenizers/",
                     "CodeSniffer/DocGenerators/",
                     "CodeSniffer/Standards/AbstractPatternSniff.php",
@@ -2425,13 +2426,13 @@
                     "role": "lead"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenises PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
             "homepage": "http://www.squizlabs.com/php-codesniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-04 22:32:15"
+            "time": "2015-06-24 03:16:23"
         },
         {
             "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
cf #7 

Suite à https://github.com/M6Web/Coke/releases/tag/v2.1.0 et https://github.com/M6Web/Symfony2-coding-standard/releases/tag/v3.0.0 on peux mettre à jour phpcs en version 2.
